### PR TITLE
Fixed System dropdown menu

### DIFF
--- a/astdb.php
+++ b/astdb.php
@@ -24,7 +24,7 @@
    - Minor edits to messages
  */
 
-$dir = "/var/www/html/allmon2/";
+$dir = getcwd() . "/";
 $db = $dir . "astdb.txt";
 $privatefile = $dir . "privatenodes.txt";
 

--- a/menu.inc
+++ b/menu.inc
@@ -61,7 +61,7 @@ foreach ($systems as $sysName => $items) {
         //$outBuf .= "</li>";
     } else {
         $outBuf .= "<li class=\"dropdown nav-item\">\n";
-        $outBuf .= "<a href=\"#\" class=\"nav-link dropdown-toggle\">$sysName</a>\n";
+        $outBuf .= "<a href=\"#\" class=\"nav-link dropdown-toggle\" data-toggle=\"dropdown\">$sysName</a>\n";
         $outBuf .= "<div class=\"dropdown-menu\">\n";
         foreach($items as $itemName => $itemValue) {
             $outBuf .= "  <a class=\"dropdown-item\" href=\"" . $itemValue['url'] .  "\">$itemName</a>\n";


### PR DESCRIPTION
The dropdown menu when configured for a system is broken. Adding data-toggle="dropdown" fixes this issue. 